### PR TITLE
fix incorrect constant for sync tile reducer and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-tiles",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Library to create and easily compose redux pieces together",
   "jsnext:main": "lib/es2015/index.js",
   "module": "lib/es2015/index.js",

--- a/src/tiles/index.ts
+++ b/src/tiles/index.ts
@@ -110,7 +110,7 @@ export function createSyncTile(params: ISyncTileParams): ITile {
   action.reset = createResetAction({ type: types.RESET });
 
   const reducerObject: ReducerObject = {
-    [types.TYPE]: (_storeState: {}, storeAction: IReducerAction): SyncData =>
+    [types.SET]: (_storeState: {}, storeAction: IReducerAction): SyncData =>
       storeAction.payload && storeAction.payload.data,
     [types.RESET]: initialState
   };


### PR DESCRIPTION
Constant was old, and it was not covered by tests. Added tests for both cases (sync and async).