### PR TITLE
Bugfix/consistent initial state

### DIFF
--- a/docs/api/createSyncTile.md
+++ b/docs/api/createSyncTile.md
@@ -39,5 +39,30 @@ const chooseParams = createSyncTile({
   // same as in `createTile` – separate data, so they will stored inside
   // store independently
   nesting: ({ type }) => [type],
+
+  // initial state to put into reducer. If you store list of elements,
+  // and don't want to check whether type of data is array or object,
+  // use this property
+  initialState: [],
+});
+```
+
+## Example
+
+Let's create a tile for listing list of all notifications which were triggered. We won't remove them here for the sake of simplicity, but we can easily add it with filtering. 
+
+```javascript
+import { createSyncTile } from 'redux-tiles';
+
+const notificationsList = createSyncTile({
+  // to have nice nesting inside redux state
+  type: ['ui', 'notifications'],
+  // this is a sync function, but we can dispatch async actions inside as well
+  fn: ({ selectors, getState, params: newNotification }) => {
+    const currentList = selectors.ui.notifications(getState());
+    return currentList.concat(newNotification);
+  },
+  // to avoid checks which type data for module is right now
+  initialState: [],
 });
 ```

--- a/docs/api/createTile.md
+++ b/docs/api/createTile.md
@@ -41,6 +41,7 @@ const userTile = createTile({
   // all passed middleware, and params – object with which dispatched
   // function was invoked
   // e.g. here: dispatch(actions.hn_api.user({ id: 'someID' }));
+  // result of the promise will be placed under `data` inside state
   fn: ({ api, params }) => api.get(`/api/user/${params.id}`),
   
   // nesting allows you to separate your data (first argument is params

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redux-tiles",
-  "version": "0.4.9",
-  "description": "Library to create and easily compose redux pieces together",
+  "version": "0.4.10",
+  "description": "Library to create and easily compose redux pieces together in less verbose manner",
   "jsnext:main": "lib/es2015/index.js",
   "module": "lib/es2015/index.js",
   "typings": "lib/es2015/index.d.ts",

--- a/src/tiles/index.ts
+++ b/src/tiles/index.ts
@@ -29,7 +29,18 @@ export interface IReducerAction {
 }
 
 export function createTile(params: ITileParams): ITile {
-  const { type, fn, caching, initialState = {}, nesting, selectorFallback = null } = params;
+  const {
+    type,
+    fn,
+    caching,
+    initialState = {
+      isPending: false,
+      error: null,
+      data: null
+    },
+    nesting,
+    selectorFallback = null
+  } = params;
   const identificator: string = createType({ type });
   const types: ITypes = {
     START: `${prefix}${identificator}_START`,

--- a/test/createReducers.spec.ts
+++ b/test/createReducers.spec.ts
@@ -50,7 +50,7 @@ test('createReducers should create no nesting by default', () => {
 
   expect(newState).toEqual({
     some: { data: null, isPending: true, error: null },
-    another: {}
+    another: { data: null, isPending: false, error: null }
   });
 });
 
@@ -133,7 +133,7 @@ test('createReducers should create correct nesting', () => {
       nesting: { data: null, isPending: true, error: null }
     },
     another: {
-      nesting: {}
+      nesting: { data: null, isPending: false, error: null }
     }
   });
 });

--- a/test/tiles.spec.ts
+++ b/test/tiles.spec.ts
@@ -107,6 +107,19 @@ test('createSyncTile should update values after dispatching action correctly', (
   expect(result).toBe('some');
 });
 
+test('createTile should have correct default initial state', async () => {
+  const someTile = createTile({
+    type: 'some',
+    fn: () => Promise.resolve({ some: true }),
+  });
+  const tiles = [someTile];
+  const { reducer, actions, selectors } = createEntities(tiles);
+  const { middleware } = createMiddleware();
+  const store = createStore(reducer, applyMiddleware(middleware));
+  const result = selectors.some(store.getState());
+  expect(result).toEqual({ isPending: false, error: null, data: null });
+});
+
 test('createTile should update values after dispatching action correctly', async () => {
   const someTile = createTile({
     type: 'some',


### PR DESCRIPTION
Before I put just an empty object to async tile, but in fact it is much more consistent to always put `{ isPending, data, error }` structure there.