### PR TITLE
add fetched field to async tile data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-tiles",
-  "version": "0.6.1",
+  "version": "0.7.0-beta.1",
   "description": "Library to create and easily compose redux pieces together in less verbose manner",
   "jsnext:main": "lib/es2015/index.js",
   "module": "lib/es2015/index.js",

--- a/src/tiles/actions.ts
+++ b/src/tiles/actions.ts
@@ -27,11 +27,25 @@ function proccessMiddleware(args: any[]): IProcessedMiddleware {
   throw new Error('Redux-Tiles expects own middleware, or redux-thunk');
 }
 
-function shouldBeFetched({ getState, selectors, params }: any): boolean {
-  const { isPending, data, error } = selectors.get(getState(), params);
+export function shouldBeFetched({ getState, selectors, params }: any): boolean {
+  const { isPending, fetched, error } = selectors.get(getState(), params);
 
-  // == intentionally to check on empty objects
-  return error == null && data == null && isPending !== true;
+  // if it is pending, then we have to wait anyway
+  if (isPending) {
+    return false;
+  }
+
+  // in case it was not fetched yet, we have to fetch it for the first time
+  if (fetched === false) {
+    return true;
+  }
+
+  // and if error is not null or undefined, we have to re-fetch it again
+  if (error != null) {
+    return true;
+  }
+
+  return false;
 }
 
 function handleMiddleware(fn: Function): FnResult {

--- a/src/tiles/index.ts
+++ b/src/tiles/index.ts
@@ -52,7 +52,8 @@ export function createTile(params: ITileParams): ITile {
     selectorFallback: {
       isPending: false,
       error: null,
-      data: selectorFallback
+      data: selectorFallback,
+      fetched: false,
     },
     tileName: type,
     nesting
@@ -77,17 +78,20 @@ export function createTile(params: ITileParams): ITile {
     [types.START]: {
       data: null,
       isPending: true,
-      error: null
+      error: null,
+      fetched: false,
     },
     [types.FAILURE]: (_storeState: {}, storeAction: IReducerAction): IData => ({
       data: null,
       isPending: false,
-      error: storeAction.error
+      error: storeAction.error,
+      fetched: true,
     }),
     [types.SUCCESS]: (_storeState: {}, storeAction: IReducerAction): IData => ({
       error: null,
       isPending: false,
-      data: storeAction.payload && storeAction.payload.data
+      data: storeAction.payload && storeAction.payload.data,
+      fetched: true,
     }),
     [types.RESET]: initialState
   };

--- a/src/tiles/types.ts
+++ b/src/tiles/types.ts
@@ -70,6 +70,7 @@ export interface IData {
   isPending: boolean;
   error: any;
   data: any;
+  fetched: boolean;
 }
 
 export type SyncData = any;

--- a/test/actions.spec.ts
+++ b/test/actions.spec.ts
@@ -127,7 +127,7 @@ test('asyncAction should\'t invoke dispatch if is loading with caching', async (
     type: 'some',
     START, FAILURE, SUCCESS,
     selectors: {
-      get: () => ({ isPending: true }),
+      get: () => ({ isPending: true, error: null, fetched: false }),
     },
     fn: () => Promise.resolve(13),
     caching: true

--- a/test/createReducers.spec.ts
+++ b/test/createReducers.spec.ts
@@ -49,7 +49,7 @@ test('createReducers should create no nesting by default', () => {
   });
 
   expect(newState).toEqual({
-    some: { data: null, isPending: true, error: null },
+    some: { data: null, isPending: true, error: null, fetched: false },
     another: null,
   });
 });
@@ -136,7 +136,7 @@ test('createReducers should create correct nesting', () => {
 
   expect(newState).toEqual({
     some: {
-      nesting: { data: null, isPending: true, error: null }
+      nesting: { data: null, isPending: true, error: null, fetched: false }
     },
     another: {
       nesting: null,

--- a/test/shouldBeFetched.spec.ts
+++ b/test/shouldBeFetched.spec.ts
@@ -1,0 +1,53 @@
+import { shouldBeFetched } from '../src/tiles/actions';
+
+test('shouldBeFetched should fetch if was not fetched', () => {
+  const getState = () => {};
+  const selectors = {
+    get: () => ({
+      isPending: false,
+      fetched: false,
+      error: null,
+    }),
+  };
+  const result = shouldBeFetched({ selectors, getState });
+  expect(result).toBe(true);
+});
+
+test('shouldBeFetched should fetch if was fetched with an error', () => {
+  const getState = () => {};
+  const selectors = {
+    get: () => ({
+      isPending: false,
+      fetched: true,
+      error: new Error('some'),
+    }),
+  };
+  const result = shouldBeFetched({ selectors, getState });
+  expect(result).toBe(true);
+});
+
+test('shouldBeFetched should not fetch if no error and was fetched', () => {
+  const getState = () => {};
+  const selectors = {
+    get: () => ({
+      isPending: false,
+      fetched: true,
+      error: null,
+    }),
+  };
+  const result = shouldBeFetched({ selectors, getState });
+  expect(result).toBe(false);
+});
+
+test('shouldBeFetched should not fetch if in process', () => {
+  const getState = () => {};
+  const selectors = {
+    get: () => ({
+      isPending: true,
+      fetched: false,
+      error: null,
+    }),
+  };
+  const result = shouldBeFetched({ selectors, getState });
+  expect(result).toBe(false);
+});

--- a/test/tiles.spec.ts
+++ b/test/tiles.spec.ts
@@ -32,7 +32,7 @@ test('createTile should return default value if not in the state', () => {
 
   const data = syncTile.selectors.get({});
 
-  expect(data).toEqual({ data: null, error: null, isPending: false });
+  expect(data).toEqual({ data: null, error: null, isPending: false, fetched: false });
 });
 
 test('createTile should return overriden value if not in the state', () => {
@@ -45,7 +45,7 @@ test('createTile should return overriden value if not in the state', () => {
 
   const data = tile.selectors.get({});
 
-  expect(data).toEqual({ isPending: false, error: null, data: { myProperty: true } });
+  expect(data).toEqual({ isPending: false, error: null, data: { myProperty: true }, fetched: false });
 });
 
 test('createTile should create new state if error', () => {
@@ -61,7 +61,7 @@ test('createTile should create new state if error', () => {
     error: new Error('some')
   };
   const newState: {} = someTile.reducer({}, action);
-  expect(newState).toEqual({ isPending: false, error, data: null });
+  expect(newState).toEqual({ isPending: false, error, data: null, fetched: true, });
 });
 
 test('createSyncTile should return overriden value if not in the state', () => {
@@ -118,7 +118,7 @@ test('createTile should have correct default initial state', async () => {
   const { middleware } = createMiddleware();
   const store = createStore(reducer, applyMiddleware(middleware));
   const result = selectors.some(store.getState());
-  expect(result).toEqual({ isPending: false, error: null, data: null });
+  expect(result).toEqual({ isPending: false, error: null, data: null, fetched: false });
 });
 
 test('createTile should update values after dispatching action correctly', async () => {
@@ -132,7 +132,7 @@ test('createTile should update values after dispatching action correctly', async
   const store = createStore(reducer, applyMiddleware(middleware));
   await store.dispatch(actions.some('some'));
   const result = selectors.some(store.getState());
-  expect(result).toEqual({ isPending: false, error: null, data: { some: true } });
+  expect(result).toEqual({ isPending: false, error: null, data: { some: true }, fetched: true });
 });
 
 test('createTile should update values after dispatching action with rejection correctly', async () => {
@@ -146,7 +146,7 @@ test('createTile should update values after dispatching action with rejection co
   const store = createStore(reducer, applyMiddleware(middleware));
   await store.dispatch(actions.some('some'));
   const result = selectors.some(store.getState());
-  expect(result).toEqual({ isPending: false, data: null, error: { some: true } });
+  expect(result).toEqual({ isPending: false, data: null, error: { some: true }, fetched: true });
 });
 
 test('createTile should keep only one active request if caching', async () => {

--- a/test/waitTiles.spec.ts
+++ b/test/waitTiles.spec.ts
@@ -49,6 +49,7 @@ test('waitTiles should wait until all promises will be resolved in storage',  as
         data: { success: true },
         isPending: false,
         error: null,
+        fetched: true,
       },
     },
     second: {
@@ -56,6 +57,7 @@ test('waitTiles should wait until all promises will be resolved in storage',  as
         data: { data: 'some' },
         isPending: false,
         error: null,
+        fetched: true,
       },
     },
   });
@@ -84,6 +86,7 @@ test('waitTiles should wait until all promises will be resolved in storage',  as
         data: { success: true },
         isPending: false,
         error: null,
+        fetched: true,
       },
     },
     second_tile: {
@@ -91,6 +94,7 @@ test('waitTiles should wait until all promises will be resolved in storage',  as
         data: { data: 'some' },
         isPending: false,
         error: null,
+        fetched: true,
       },
     },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,13 +34,6 @@ acorn@^4.0.1, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -738,10 +731,6 @@ caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
 
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -801,10 +790,6 @@ cmd-shim@~2.0.2:
   dependencies:
     graceful-fs "^4.1.2"
     mkdirp "~0.5.0"
-
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -1377,10 +1362,6 @@ handlebars@^4.0.3:
   optionalDependencies:
     uglify-js "^2.6"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-
 har-validator@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
@@ -1389,13 +1370,6 @@ har-validator@~2.0.6:
     commander "^2.9.0"
     is-my-json-valid "^2.12.4"
     pinkie-promise "^2.0.0"
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -2767,10 +2741,6 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -2845,10 +2815,6 @@ qs@~6.2.0:
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
-
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 randomatic@^1.1.3:
   version "1.1.6"
@@ -3036,7 +3002,32 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2, request@^2.47.0, request@~2.69.0:
+request@2, request@2.79.0, request@^2.47.0, request@^2.74.0, request@^2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+    uuid "^3.0.0"
+
+request@~2.69.0:
   version "2.69.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.69.0.tgz#cf91d2e000752b1217155c005241911991a2346a"
   dependencies:
@@ -3062,32 +3053,7 @@ request@2, request@^2.47.0, request@~2.69.0:
     tough-cookie "~2.2.0"
     tunnel-agent "~0.4.1"
 
-request@2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
-
-request@^2.74.0, request@~2.74.0:
+request@~2.74.0:
   version "2.74.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.74.0.tgz#7693ca768bbb0ea5c8ce08c084a45efa05b892ab"
   dependencies:
@@ -3112,33 +3078,6 @@ request@^2.74.0, request@~2.74.0:
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
-
-request@^2.79.0:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -3253,7 +3192,7 @@ rollup@^0.41.4:
   dependencies:
     source-map-support "^0.4.0"
 
-safe-buffer@^5.0.1, safe-buffer@~5.0.1:
+safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
@@ -3557,12 +3496,6 @@ tslint@^5.3.2:
 tsutils@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.2.0.tgz#218614657f21c677e4536b4ba75daf8ebce1b367"
-
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  dependencies:
-    safe-buffer "^5.0.1"
 
 tunnel-agent@~0.4.1:
   version "0.4.3"


### PR DESCRIPTION
Previously the data structure for async tile looked like the following:

```js
{
  data: null,
  error: null,
  isPending: false,
}
```

The problem is that we can't keep `null` inside `data` (and all falsy values are hard to keep), so this PR moves responsibility of it to another field, `fetched`.
Now data structure looks like this:

```js
{
  data: null,
  error: null,
  fetched: true,
  isPending: false,
}
```

So we can safely return null, and based on `fetched` decide whether it was done or not.