### PR TITLE
Feature/add data error properties to dispatch results

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,7 @@ const authUser = createTile({
   type: ['user', 'auth'],
   fn: async ({ params, dispatch, actions, selectors, getState }) => {
     // login user
-    await dispatch(actions.tiles.user.authRequest(params));
-    
-    // check the result
-    const { data: { id }, error } = selectors.tiles.user.authRequest(getState());
+    const { data: { id }, error } = await dispatch(actions.tiles.user.authRequest(params));
 
     if (error) {
       throw new Error(error);

--- a/docs/examples/hacker-news-api.md
+++ b/docs/examples/hacker-news-api.md
@@ -57,8 +57,7 @@ export const itemsByPageTile = createTile({
   fn: async ({ params: { type = 'topstories', pageNumber = 0, pageSize = 30 }, selectors, getState, actions, dispatch }) => {
     // we can always fetch stories, they are cached, so if this type
     // was already fetched, there will be no new request
-    await dispatch(actions.hn_api.stories({ type }));
-    const { data } = selectors.hn_api.stories(getState(), { type });
+    const { data } = await dispatch(actions.hn_api.stories({ type }));
     const offset = pageNumber * pageSize;
     const end = offset + pageSize;
     const ids = data.slice(offset, end);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-tiles",
-  "version": "0.8.0-beta2",
+  "version": "0.8.0",
   "description": "Library to create and easily compose redux pieces together in less verbose manner",
   "jsnext:main": "lib/es2015/index.js",
   "module": "lib/es2015/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-tiles",
-  "version": "0.8.0-beta1",
+  "version": "0.8.0-beta2",
   "description": "Library to create and easily compose redux pieces together in less verbose manner",
   "jsnext:main": "lib/es2015/index.js",
   "module": "lib/es2015/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-tiles",
-  "version": "0.7.1",
+  "version": "0.8.0-beta1",
   "description": "Library to create and easily compose redux pieces together in less verbose manner",
   "jsnext:main": "lib/es2015/index.js",
   "module": "lib/es2015/index.js",

--- a/src/tiles/actions.ts
+++ b/src/tiles/actions.ts
@@ -84,24 +84,28 @@ export function asyncAction({
 
     dispatch({
       type: START,
-      payload: { path }
+      payload: { path },
+      isPending: true
     });
 
     const promise: Promise<any> = fn({ params, dispatch, getState, ...middlewares })
       .then((data: any) => {
-        dispatch({
-          type: SUCCESS,
-          payload: { path, data }
-        });
         promisesStorage[getIdentificator] = undefined;
+        return dispatch({
+          type: SUCCESS,
+          payload: { path, data },
+          data,
+          isPending: false
+        });
       })
       .catch((error: any) => {
-        dispatch({
+        promisesStorage[getIdentificator] = undefined;
+        return dispatch({
           error,
           type: FAILURE,
-          payload: { path }
+          payload: { path },
+          isPending: false,
         });
-        promisesStorage[getIdentificator] = undefined;
       });
 
     promisesStorage[getIdentificator] = promise;
@@ -117,13 +121,15 @@ export function createResetAction({ type }: { type: string }): Function {
 export function syncAction({ SET, fn, nesting }: ISyncActionTypes): FnResult {
   return handleMiddleware(({ dispatch, getState, ...middlewares }: any, params: any) => {
     const path: string[]|null = nesting ? nesting(params) : null;
+    const data = fn({ params, dispatch, getState, ...middlewares });
 
     return dispatch({
       type: SET,
       payload: {
         path,
-        data: fn({ params, dispatch, getState, ...middlewares })
-      }
+        data
+      },
+      data
     });
   });
 }

--- a/src/tiles/actions.ts
+++ b/src/tiles/actions.ts
@@ -27,9 +27,7 @@ function proccessMiddleware(args: any[]): IProcessedMiddleware {
   throw new Error('Redux-Tiles expects own middleware, or redux-thunk');
 }
 
-export function shouldBeFetched({ getState, selectors, params }: any): boolean {
-  const { isPending, fetched, error } = selectors.get(getState(), params);
-
+export function shouldBeFetched({ isPending, fetched, error }: any): boolean {
   // if it is pending, then we have to wait anyway
   if (isPending) {
     return false;
@@ -75,10 +73,11 @@ export function asyncAction({
     }
 
     if (caching && !forceAsync) {
-      const isFetchingNeeded: boolean = shouldBeFetched({ getState, selectors, params });
+      const { isPending, fetched, error, data } = selectors.get(getState(), params);
+      const isFetchingNeeded: boolean = shouldBeFetched({ isPending, fetched, error });
 
       if (!isFetchingNeeded) {
-        return Promise.resolve();
+        return Promise.resolve({ data, error, isPending });
       }
     }
 

--- a/test/shouldBeFetched.spec.ts
+++ b/test/shouldBeFetched.spec.ts
@@ -1,53 +1,41 @@
 import { shouldBeFetched } from '../src/tiles/actions';
 
 test('shouldBeFetched should fetch if was not fetched', () => {
-  const getState = () => {};
-  const selectors = {
-    get: () => ({
-      isPending: false,
-      fetched: false,
-      error: null,
-    }),
+  const params = {
+    isPending: false,
+    fetched: false,
+    error: null,
   };
-  const result = shouldBeFetched({ selectors, getState });
+  const result = shouldBeFetched(params);
   expect(result).toBe(true);
 });
 
 test('shouldBeFetched should fetch if was fetched with an error', () => {
-  const getState = () => {};
-  const selectors = {
-    get: () => ({
-      isPending: false,
-      fetched: true,
-      error: new Error('some'),
-    }),
+  const params = {
+    isPending: false,
+    fetched: true,
+    error: new Error('some'),
   };
-  const result = shouldBeFetched({ selectors, getState });
+  const result = shouldBeFetched(params);
   expect(result).toBe(true);
 });
 
 test('shouldBeFetched should not fetch if no error and was fetched', () => {
-  const getState = () => {};
-  const selectors = {
-    get: () => ({
-      isPending: false,
-      fetched: true,
-      error: null,
-    }),
+  const params = {
+    isPending: false,
+    fetched: true,
+    error: null,
   };
-  const result = shouldBeFetched({ selectors, getState });
+  const result = shouldBeFetched(params);
   expect(result).toBe(false);
 });
 
 test('shouldBeFetched should not fetch if in process', () => {
-  const getState = () => {};
-  const selectors = {
-    get: () => ({
-      isPending: true,
-      fetched: false,
-      error: null,
-    }),
+  const params = {
+    isPending: true,
+    fetched: false,
+    error: null,
   };
-  const result = shouldBeFetched({ selectors, getState });
+  const result = shouldBeFetched(params);
   expect(result).toBe(false);
 });

--- a/test/tiles.spec.ts
+++ b/test/tiles.spec.ts
@@ -148,6 +148,21 @@ test('createTile should receive data property after dispatching action correctly
   expect(result).toEqual({ some: true });
 });
 
+test('createTile should receive data property after dispatching action correctly with cached version', async () => {
+  const someTile = createTile({
+    type: 'some',
+    fn: () => Promise.resolve({ some: true }),
+    caching: true
+  });
+  const tiles = [someTile];
+  const { reducer, actions, selectors } = createEntities(tiles);
+  const { middleware } = createMiddleware();
+  const store = createStore(reducer, applyMiddleware(middleware));
+  await store.dispatch(actions.some('some'));
+  const { data: result } = await store.dispatch(actions.some('some'));
+  expect(result).toEqual({ some: true });
+});
+
 test('createTile should update values after dispatching action with rejection correctly', async () => {
   const someTile = createTile({
     type: 'some',

--- a/test/tiles.spec.ts
+++ b/test/tiles.spec.ts
@@ -92,7 +92,8 @@ test('createSyncTile should return params if no function was given', () => {
     payload: {
       path: null,
       data: params
-    }
+    },
+    data: params
   };
   expect(arg).toEqual(resultAction);
 });
@@ -103,8 +104,7 @@ test('createSyncTile should update values after dispatching action correctly', (
   const { reducer, actions, selectors } = createEntities(tiles);
   const { middleware } = createMiddleware();
   const store = createStore(reducer, applyMiddleware(middleware));
-  store.dispatch(actions.some('some'));
-  const result = selectors.some(store.getState());
+  const { data: result } = store.dispatch(actions.some('some'));
   expect(result).toBe('some');
 });
 
@@ -135,6 +135,19 @@ test('createTile should update values after dispatching action correctly', async
   expect(result).toEqual({ isPending: false, error: null, data: { some: true }, fetched: true });
 });
 
+test('createTile should receive data property after dispatching action correctly', async () => {
+  const someTile = createTile({
+    type: 'some',
+    fn: () => Promise.resolve({ some: true }),
+  });
+  const tiles = [someTile];
+  const { reducer, actions, selectors } = createEntities(tiles);
+  const { middleware } = createMiddleware();
+  const store = createStore(reducer, applyMiddleware(middleware));
+  const { data: result } = await store.dispatch(actions.some('some'));
+  expect(result).toEqual({ some: true });
+});
+
 test('createTile should update values after dispatching action with rejection correctly', async () => {
   const someTile = createTile({
     type: 'some',
@@ -147,6 +160,19 @@ test('createTile should update values after dispatching action with rejection co
   await store.dispatch(actions.some('some'));
   const result = selectors.some(store.getState());
   expect(result).toEqual({ isPending: false, data: null, error: { some: true }, fetched: true });
+});
+
+test('createTile should receive error property after dispatching action with rejection correctly', async () => {
+  const someTile = createTile({
+    type: 'some',
+    fn: () => Promise.reject({ some: true }),
+  });
+  const tiles = [someTile];
+  const { reducer, actions, selectors } = createEntities(tiles);
+  const { middleware } = createMiddleware();
+  const store = createStore(reducer, applyMiddleware(middleware));
+  const { error: result } = await store.dispatch(actions.some('some'));
+  expect(result).toEqual({ some: true });
 });
 
 test('createTile should keep only one active request if caching', async () => {


### PR DESCRIPTION
As described in the issue #22 , it would be nice to remove cluttering in docs and using it, so this PR allows to avoid writing selecting code constantly after dispatching requests.